### PR TITLE
refactor(query-result): use claims

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,10 +31,10 @@
   "dependencies": {
     "@ipld/dag-cbor": "^9.2.2",
     "@storacha/blob-index": "^0.0.0",
-    "@ucanto/core": "^10.0.1",
+    "@ucanto/core": "^10.1.1",
     "@ucanto/interface": "^10.0.1",
-    "multiformats": "^13.3.1",
-    "zod": "^3.23.8"
+    "@web3-storage/content-claims": "5.1.4-rc.4",
+    "multiformats": "^13.3.1"
   },
   "devDependencies": {
     "@types/chai": "^5.0.1",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "@storacha/blob-index": "^0.0.0",
     "@ucanto/core": "^10.1.1",
     "@ucanto/interface": "^10.0.1",
-    "@web3-storage/content-claims": "5.1.4-rc.5",
+    "@web3-storage/content-claims": "5.2.0",
     "multiformats": "^13.3.1"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "@storacha/blob-index": "^0.0.0",
     "@ucanto/core": "^10.1.1",
     "@ucanto/interface": "^10.0.1",
-    "@web3-storage/content-claims": "5.1.4-rc.4",
+    "@web3-storage/content-claims": "5.1.4-rc.5",
     "multiformats": "^13.3.1"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,8 +21,8 @@ importers:
         specifier: ^10.0.1
         version: 10.0.1
       '@web3-storage/content-claims':
-        specifier: 5.1.4-rc.5
-        version: 5.1.4-rc.5
+        specifier: 5.2.0
+        version: 5.2.0
       multiformats:
         specifier: ^13.3.1
         version: 13.3.1
@@ -120,8 +120,8 @@ packages:
   '@ucanto/validator@9.0.2':
     resolution: {integrity: sha512-LxhRbDMIoLt9LYHq/Rz1WCEH8AtmdsBTS/it28Ij/A3W0zyoSwUpAUxBtXaKRh/gpbxdWmjxX+nVfFJYL//b4g==}
 
-  '@web3-storage/content-claims@5.1.4-rc.5':
-    resolution: {integrity: sha512-gVY6WpUhDmoyCI9v8gFNl0ASuChBEfbjKdub5lNsMuyr5le6DQ8D95v3o2Aa042f2qFRFdRw79ryEWJfDa8Btw==}
+  '@web3-storage/content-claims@5.2.0':
+    resolution: {integrity: sha512-FV1WIfo+lL9igjkAtHU2dl2blJfoWCWnmCAO4bhFpZD2MwojUWlVHP1t6y6qL7QU1+o7Ax9tpiAWYsb1U7Pixg==}
 
   '@web3-storage/data-segment@5.3.0':
     resolution: {integrity: sha512-zFJ4m+pEKqtKatJNsFrk/2lHeFSbkXZ6KKXjBe7/2ayA9wAar7T/unewnOcZrrZTnCWmaxKsXWqdMFy9bXK9dw==}
@@ -587,7 +587,7 @@ snapshots:
       '@ucanto/interface': 10.0.1
       multiformats: 11.0.2
 
-  '@web3-storage/content-claims@5.1.4-rc.5':
+  '@web3-storage/content-claims@5.2.0':
     dependencies:
       '@ucanto/client': 9.0.1
       '@ucanto/core': 10.1.1

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,8 +21,8 @@ importers:
         specifier: ^10.0.1
         version: 10.0.1
       '@web3-storage/content-claims':
-        specifier: 5.1.4-rc.4
-        version: 5.1.4-rc.4
+        specifier: 5.1.4-rc.5
+        version: 5.1.4-rc.5
       multiformats:
         specifier: ^13.3.1
         version: 13.3.1
@@ -120,8 +120,8 @@ packages:
   '@ucanto/validator@9.0.2':
     resolution: {integrity: sha512-LxhRbDMIoLt9LYHq/Rz1WCEH8AtmdsBTS/it28Ij/A3W0zyoSwUpAUxBtXaKRh/gpbxdWmjxX+nVfFJYL//b4g==}
 
-  '@web3-storage/content-claims@5.1.4-rc.4':
-    resolution: {integrity: sha512-ZZaFuaa0JVyqV/M4zkAJWT6z8EZUjI88xfkmVzwqlsztUEuMdXhjBXy+Bud0Y4v0pgHvQ2OGzXxTSHAKh89ZMg==}
+  '@web3-storage/content-claims@5.1.4-rc.5':
+    resolution: {integrity: sha512-gVY6WpUhDmoyCI9v8gFNl0ASuChBEfbjKdub5lNsMuyr5le6DQ8D95v3o2Aa042f2qFRFdRw79ryEWJfDa8Btw==}
 
   '@web3-storage/data-segment@5.3.0':
     resolution: {integrity: sha512-zFJ4m+pEKqtKatJNsFrk/2lHeFSbkXZ6KKXjBe7/2ayA9wAar7T/unewnOcZrrZTnCWmaxKsXWqdMFy9bXK9dw==}
@@ -587,7 +587,7 @@ snapshots:
       '@ucanto/interface': 10.0.1
       multiformats: 11.0.2
 
-  '@web3-storage/content-claims@5.1.4-rc.4':
+  '@web3-storage/content-claims@5.1.4-rc.5':
     dependencies:
       '@ucanto/client': 9.0.1
       '@ucanto/core': 10.1.1

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,17 +15,17 @@ importers:
         specifier: ^0.0.0
         version: 0.0.0
       '@ucanto/core':
-        specifier: ^10.0.1
-        version: 10.0.1
+        specifier: ^10.1.1
+        version: 10.1.1
       '@ucanto/interface':
         specifier: ^10.0.1
         version: 10.0.1
+      '@web3-storage/content-claims':
+        specifier: 5.1.4-rc.4
+        version: 5.1.4-rc.4
       multiformats:
         specifier: ^13.3.1
         version: 13.3.1
-      zod:
-        specifier: ^3.23.8
-        version: 3.23.8
     devDependencies:
       '@types/chai':
         specifier: ^5.0.1
@@ -96,20 +96,32 @@ packages:
   '@types/node@22.9.0':
     resolution: {integrity: sha512-vuyHg81vvWA1Z1ELfvLko2c8f34gyA0zaic0+Rllc5lbCnbSyuvb2Oxpm6TAUAC/2xZN3QGqxBNggD1nNR2AfQ==}
 
-  '@ucanto/core@10.0.1':
-    resolution: {integrity: sha512-1BfUaJu0/c9Rl/WdZSDbScJJLsPsPe1g4ynl5kubUj3xDD/lyp/Q12PQVQ2X7hDiWwkpwmxCkRMkOxwc70iNKQ==}
+  '@ucanto/client@9.0.1':
+    resolution: {integrity: sha512-cV8w3AnaZaYCdUmyFFICj8YhFckDoy2DvWgAzGDMkPz0WbUW4lw9Tjm4hEE8x5kiP47wYej/pHKWCcoELiU0qw==}
+
+  '@ucanto/core@10.1.1':
+    resolution: {integrity: sha512-Dypn1hlWvP4kFLuM98U02c8anFuT8hrR3uVi7YZ3wTyBeKOhl/0ggGBR06eyXLw6EL15Yp7dR3Mlce9jTEPwlA==}
 
   '@ucanto/interface@10.0.1':
     resolution: {integrity: sha512-+Vr/N4mLsdynV9/bqtdFiq7WsUf3265/Qx2aHJmPtXo9/QvWKthJtpe0g8U4NWkWpVfqIFvyAO2db6D9zWQfQw==}
 
+  '@ucanto/interface@10.0.2':
+    resolution: {integrity: sha512-0n1H6ChvC1moQl2lnGMdSN/ThfCiJ99VdyTtfiu/380vcf3U3Sb8soIrAWE9mM9KysNZUWfJBB0ahj5vganeoA==}
+
   '@ucanto/principal@9.0.1':
     resolution: {integrity: sha512-8eAvaZHW1vyET4X90rkJv6pmW1IOdEYlZYwO3wDgTkC5m9VytBEywCvpzP57cavdYIbbPse5QS9nMEGvk87zhw==}
+
+  '@ucanto/server@10.0.2':
+    resolution: {integrity: sha512-UNO4MAVXnMFP13JgcO3bZcfbW6FS4agZJJGozlo9FxNcUorfrRNTJ+uSmUStszjO+uHYzpIi0dPNRge2Fmm38Q==}
 
   '@ucanto/transport@9.1.1':
     resolution: {integrity: sha512-3CR17nEemOVaTuMZa6waWgVL4sLxSPcxYvpaNeJ6NZo1rfsqdyRXOtbVV/RcI2BtUL0Cao6JM6P9+gdghfc5ng==}
 
   '@ucanto/validator@9.0.2':
     resolution: {integrity: sha512-LxhRbDMIoLt9LYHq/Rz1WCEH8AtmdsBTS/it28Ij/A3W0zyoSwUpAUxBtXaKRh/gpbxdWmjxX+nVfFJYL//b4g==}
+
+  '@web3-storage/content-claims@5.1.4-rc.4':
+    resolution: {integrity: sha512-ZZaFuaa0JVyqV/M4zkAJWT6z8EZUjI88xfkmVzwqlsztUEuMdXhjBXy+Bud0Y4v0pgHvQ2OGzXxTSHAKh89ZMg==}
 
   '@web3-storage/data-segment@5.3.0':
     resolution: {integrity: sha512-zFJ4m+pEKqtKatJNsFrk/2lHeFSbkXZ6KKXjBe7/2ayA9wAar7T/unewnOcZrrZTnCWmaxKsXWqdMFy9bXK9dw==}
@@ -454,9 +466,6 @@ packages:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
 
-  zod@3.23.8:
-    resolution: {integrity: sha512-XBx9AXhXktjUqnepgTiE5flcKIYWi/rme0Eaj+5Y0lftuGBq+jyRu/md4WnuxqgP1ubdpNCsYEYPxrzVHD8d6g==}
-
 snapshots:
 
   '@ipld/car@5.3.3':
@@ -495,7 +504,7 @@ snapshots:
       '@ipld/dag-cbor': 9.2.2
       '@storacha/capabilities': 0.0.0
       '@storacha/one-webcrypto': 1.0.1
-      '@ucanto/core': 10.0.1
+      '@ucanto/core': 10.1.1
       '@ucanto/interface': 10.0.1
       carstream: 2.2.0
       multiformats: 13.3.1
@@ -503,7 +512,7 @@ snapshots:
 
   '@storacha/capabilities@0.0.0':
     dependencies:
-      '@ucanto/core': 10.0.1
+      '@ucanto/core': 10.1.1
       '@ucanto/interface': 10.0.1
       '@ucanto/principal': 9.0.1
       '@ucanto/transport': 9.1.1
@@ -525,15 +534,25 @@ snapshots:
     dependencies:
       undici-types: 6.19.8
 
-  '@ucanto/core@10.0.1':
+  '@ucanto/client@9.0.1':
+    dependencies:
+      '@ucanto/core': 10.1.1
+      '@ucanto/interface': 10.0.2
+
+  '@ucanto/core@10.1.1':
     dependencies:
       '@ipld/car': 5.3.3
       '@ipld/dag-cbor': 9.2.2
       '@ipld/dag-ucan': 3.4.0
-      '@ucanto/interface': 10.0.1
+      '@ucanto/interface': 10.0.2
       multiformats: 11.0.2
 
   '@ucanto/interface@10.0.1':
+    dependencies:
+      '@ipld/dag-ucan': 3.4.0
+      multiformats: 11.0.2
+
+  '@ucanto/interface@10.0.2':
     dependencies:
       '@ipld/dag-ucan': 3.4.0
       multiformats: 11.0.2
@@ -548,18 +567,35 @@ snapshots:
       multiformats: 11.0.2
       one-webcrypto: 1.0.3
 
+  '@ucanto/server@10.0.2':
+    dependencies:
+      '@ucanto/core': 10.1.1
+      '@ucanto/interface': 10.0.2
+      '@ucanto/principal': 9.0.1
+      '@ucanto/validator': 9.0.2
+
   '@ucanto/transport@9.1.1':
     dependencies:
-      '@ucanto/core': 10.0.1
+      '@ucanto/core': 10.1.1
       '@ucanto/interface': 10.0.1
 
   '@ucanto/validator@9.0.2':
     dependencies:
       '@ipld/car': 5.3.3
       '@ipld/dag-cbor': 9.2.2
-      '@ucanto/core': 10.0.1
+      '@ucanto/core': 10.1.1
       '@ucanto/interface': 10.0.1
       multiformats: 11.0.2
+
+  '@web3-storage/content-claims@5.1.4-rc.4':
+    dependencies:
+      '@ucanto/client': 9.0.1
+      '@ucanto/core': 10.1.1
+      '@ucanto/interface': 10.0.2
+      '@ucanto/server': 10.0.2
+      '@ucanto/transport': 9.1.1
+      carstream: 2.2.0
+      multiformats: 13.3.1
 
   '@web3-storage/data-segment@5.3.0':
     dependencies:
@@ -884,5 +920,3 @@ snapshots:
       yargs-parser: 20.2.9
 
   yocto-queue@0.1.0: {}
-
-  zod@3.23.8: {}

--- a/src/api.ts
+++ b/src/api.ts
@@ -19,12 +19,15 @@ export interface Match {
   subject: DID[]
 }
 
+export type Kind = "standard" | "index_or_location" | "location"
+
 /**
  * Query is a query for several multihashes.
  */
 export interface Query {
   hashes: MultihashDigest[]
   match?: Match
+  kind?: Kind
 }
 
 export interface QueryOk extends QueryResult {}

--- a/src/api.ts
+++ b/src/api.ts
@@ -1,10 +1,12 @@
 import { MultihashDigest, Link } from 'multiformats'
 import { Delegation, Failure, Result, DID, IPLDView, IPLDBlock } from '@ucanto/interface'
 import { DecodeFailure, ShardedDAGIndex, ShardedDAGIndexView, UnknownFormat } from '@storacha/blob-index/types'
+import { Claim } from '@web3-storage/content-claims/client/api'
 
 export type { MultihashDigest, Link }
 export type { Delegation, Failure, Result, DID, IPLDView, IPLDBlock }
 export type { DecodeFailure, ShardedDAGIndex, ShardedDAGIndexView, UnknownFormat }
+export type { Claim }
 
 export interface IndexingServiceClient {
   queryClaims (q: Query): Promise<Result<QueryOk, QueryError>>
@@ -28,7 +30,7 @@ export interface Query {
 export interface QueryOk extends QueryResult {}
 
 export interface QueryResult extends IPLDView {
-  claims: Map<string, Delegation>
+  claims: Map<string, Claim>
   indexes: Map<string, ShardedDAGIndex>
   archive (): Promise<Result<Uint8Array>>
 }

--- a/src/index.js
+++ b/src/index.js
@@ -31,12 +31,13 @@ export class Client {
    * @param {Query} query
    * @returns {Promise<Result<QueryOk, QueryError>>}
    */
-  async queryClaims({ hashes = [], match = { subject: [] } }) {
+  async queryClaims({ hashes = [], match = { subject: [] }, kind = "standard" }) {
     const url = new URL(CLAIMS_PATH, this.#serviceURL)
     hashes.forEach((hash) =>
       url.searchParams.append('multihash', base58btc.encode(hash.bytes))
     )
     match.subject.forEach((space) => url.searchParams.append('spaces', space))
+    url.searchParams.append('kind', kind)
 
     if (!hashes.length) {
       return error(new InvalidQueryError('missing multihashes in query'))


### PR DESCRIPTION
# Goals

- remove zod, a third party library for parsing schemas in favor of build in ucanto parser
- allow easier and unified dx by converting to query result to use actual typed claims from the content claims package
- note: I realize using the content claims package here is a bit weird, but this is a side effect of the need to unify these repos

# Implementation

- add ucanto schema for query result
- add claim parsing during query result decoding