### PR TITLE
feat: remove legacy claims

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   },
   "dependencies": {
     "@ipld/dag-cbor": "^9.2.3",
-    "@storacha/blob-index": "^1.0.6",
+    "@storacha/blob-index": "1.1.0-rc.0",
     "@storacha/capabilities": "^1.6.0",
     "@ucanto/core": "^10.4.0",
     "@ucanto/interface": "^10.3.0",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,10 @@
       "import": "./src/api.js",
       "types": "./dist/src/api.d.ts"
     },
+    "./claim": {
+      "import": "./src/claim.js",
+      "types": "./dist/src/claim.d.ts"
+    },
     "./errors": {
       "import": "./src/errors.js",
       "types": "./dist/src/errors.d.ts"

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   "dependencies": {
     "@ipld/dag-cbor": "^9.2.3",
     "@storacha/blob-index": "1.1.0-rc.0",
-    "@storacha/capabilities": "^1.6.0",
+    "@storacha/capabilities": "1.7.0-rc.0",
     "@ucanto/core": "^10.4.0",
     "@ucanto/interface": "^10.3.0",
     "multiformats": "^13.3.6"

--- a/package.json
+++ b/package.json
@@ -31,9 +31,9 @@
   "dependencies": {
     "@ipld/dag-cbor": "^9.2.3",
     "@storacha/blob-index": "^1.0.6",
+    "@storacha/capabilities": "^1.6.0",
     "@ucanto/core": "^10.4.0",
     "@ucanto/interface": "^10.3.0",
-    "@web3-storage/content-claims": "^5.2.1",
     "multiformats": "^13.3.6"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -34,8 +34,8 @@
   },
   "dependencies": {
     "@ipld/dag-cbor": "^9.2.3",
-    "@storacha/blob-index": "1.1.0-rc.0",
-    "@storacha/capabilities": "1.7.0-rc.0",
+    "@storacha/blob-index": "^1.1.0",
+    "@storacha/capabilities": "^1.7.0",
     "@ucanto/core": "^10.4.0",
     "@ucanto/interface": "^10.3.0",
     "multiformats": "^13.3.6"

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "@types/node": "^22.9.0",
     "chai": "^5.1.2",
     "mocha": "^10.8.2",
-    "typescript": "^5.6.3"
+    "typescript": "^5.8.3"
   },
   "prettier": {
     "trailingComma": "es5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,8 +15,8 @@ importers:
         specifier: 1.1.0-rc.0
         version: 1.1.0-rc.0
       '@storacha/capabilities':
-        specifier: ^1.6.0
-        version: 1.6.0
+        specifier: 1.7.0-rc.0
+        version: 1.7.0-rc.0
       '@ucanto/core':
         specifier: ^10.4.0
         version: 10.4.0
@@ -84,6 +84,9 @@ packages:
 
   '@storacha/capabilities@1.6.0':
     resolution: {integrity: sha512-feHDRYfVTY1FArKCYZdfcx6Vj5HuEglurKy9+nKb0Bf/RTyETJM9eiftWORBlJmiRzDLH4iPr6EmGdhfTanCCQ==}
+
+  '@storacha/capabilities@1.7.0-rc.0':
+    resolution: {integrity: sha512-y+BhKDY8fem15+4YstC07BQY2jLO5zD8zcsBUpnMmZOmouDfPiq/SK/e8S5FbXS7J+xcqCTamSacXLxCojsAsg==}
 
   '@storacha/one-webcrypto@1.0.1':
     resolution: {integrity: sha512-bD+vWmcgsEBqU0Dz04BR43SA03bBoLTAY29vaKasY9Oe8cb6XIP0/vkm0OS2UwKC13c8uRgFW4rjJUgDCNLejQ==}
@@ -506,6 +509,16 @@ snapshots:
       uint8arrays: 5.1.0
 
   '@storacha/capabilities@1.6.0':
+    dependencies:
+      '@ucanto/core': 10.4.0
+      '@ucanto/interface': 10.3.0
+      '@ucanto/principal': 9.0.2
+      '@ucanto/transport': 9.2.0
+      '@ucanto/validator': 9.1.0
+      '@web3-storage/data-segment': 5.3.0
+      multiformats: 13.3.6
+
+  '@storacha/capabilities@1.7.0-rc.0':
     dependencies:
       '@ucanto/core': 10.4.0
       '@ucanto/interface': 10.3.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,11 +12,11 @@ importers:
         specifier: ^9.2.3
         version: 9.2.3
       '@storacha/blob-index':
-        specifier: 1.1.0-rc.0
-        version: 1.1.0-rc.0
+        specifier: ^1.1.0
+        version: 1.1.0
       '@storacha/capabilities':
-        specifier: 1.7.0-rc.0
-        version: 1.7.0-rc.0
+        specifier: ^1.7.0
+        version: 1.7.0
       '@ucanto/core':
         specifier: ^10.4.0
         version: 10.4.0
@@ -78,15 +78,12 @@ packages:
     resolution: {integrity: sha512-1j6kQFb7QRru7eKN3ZDvRcP13rugwdxZqCjbiAVZfIJwgj2A65UmT4TgARXGlXgnRkORLTDTrO19ZErt7+QXgA==}
     engines: {node: ^14.21.3 || >=16}
 
-  '@storacha/blob-index@1.1.0-rc.0':
-    resolution: {integrity: sha512-LTPfv0POAKbFJAem1Iz7utZzlh2auIhUZ7TQYz9YM9tZOWXwWz4oKXv6v0sXsqK5NGZsnolT5iQbNJ2f8GXZBg==}
+  '@storacha/blob-index@1.1.0':
+    resolution: {integrity: sha512-f8+e7N6ww/YJ83Z4GeeGuQevVueRLg3StB0kv36ia/RkOWGBzqzoDQvXnxTY5rTJzcDT712pZdVcdHJX6jwbkg==}
     engines: {node: '>=16.15'}
 
-  '@storacha/capabilities@1.6.0':
-    resolution: {integrity: sha512-feHDRYfVTY1FArKCYZdfcx6Vj5HuEglurKy9+nKb0Bf/RTyETJM9eiftWORBlJmiRzDLH4iPr6EmGdhfTanCCQ==}
-
-  '@storacha/capabilities@1.7.0-rc.0':
-    resolution: {integrity: sha512-y+BhKDY8fem15+4YstC07BQY2jLO5zD8zcsBUpnMmZOmouDfPiq/SK/e8S5FbXS7J+xcqCTamSacXLxCojsAsg==}
+  '@storacha/capabilities@1.7.0':
+    resolution: {integrity: sha512-YMIuocTgaVpqlgyds5NG+eJqfr+dfFkxdk33lJcFIRD30SZaGiA8vQ0ZPUHqcC9Azj0XZCRexz6nHXqEsn1aag==}
 
   '@storacha/one-webcrypto@1.0.1':
     resolution: {integrity: sha512-bD+vWmcgsEBqU0Dz04BR43SA03bBoLTAY29vaKasY9Oe8cb6XIP0/vkm0OS2UwKC13c8uRgFW4rjJUgDCNLejQ==}
@@ -497,10 +494,10 @@ snapshots:
 
   '@noble/hashes@1.5.0': {}
 
-  '@storacha/blob-index@1.1.0-rc.0':
+  '@storacha/blob-index@1.1.0':
     dependencies:
       '@ipld/dag-cbor': 9.2.3
-      '@storacha/capabilities': 1.6.0
+      '@storacha/capabilities': 1.7.0
       '@storacha/one-webcrypto': 1.0.1
       '@ucanto/core': 10.4.0
       '@ucanto/interface': 10.3.0
@@ -508,17 +505,7 @@ snapshots:
       multiformats: 13.3.6
       uint8arrays: 5.1.0
 
-  '@storacha/capabilities@1.6.0':
-    dependencies:
-      '@ucanto/core': 10.4.0
-      '@ucanto/interface': 10.3.0
-      '@ucanto/principal': 9.0.2
-      '@ucanto/transport': 9.2.0
-      '@ucanto/validator': 9.1.0
-      '@web3-storage/data-segment': 5.3.0
-      multiformats: 13.3.6
-
-  '@storacha/capabilities@1.7.0-rc.0':
+  '@storacha/capabilities@1.7.0':
     dependencies:
       '@ucanto/core': 10.4.0
       '@ucanto/interface': 10.3.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,15 +14,15 @@ importers:
       '@storacha/blob-index':
         specifier: ^1.0.6
         version: 1.0.6
+      '@storacha/capabilities':
+        specifier: ^1.6.0
+        version: 1.6.0
       '@ucanto/core':
         specifier: ^10.4.0
         version: 10.4.0
       '@ucanto/interface':
         specifier: ^10.3.0
         version: 10.3.0
-      '@web3-storage/content-claims':
-        specifier: ^5.2.1
-        version: 5.2.1
       multiformats:
         specifier: ^13.3.6
         version: 13.3.6
@@ -82,8 +82,8 @@ packages:
     resolution: {integrity: sha512-i0T942GU3cWI9uT2om00VRiSVypLQR47NHv97TXiDAJrZh+vT3oo2pJOjMZ9d5IDxFxDwhCN5pt/aMWLL1cj+Q==}
     engines: {node: '>=16.15'}
 
-  '@storacha/capabilities@1.5.0':
-    resolution: {integrity: sha512-URShZ1RkEHsQa/uuEtLcuQGTZ5gzClfJ4UVm0KRivGnP+p8GvFnXnzmPRvaaYOkw/PhChe3e5oeVzvVNSOSsiA==}
+  '@storacha/capabilities@1.6.0':
+    resolution: {integrity: sha512-feHDRYfVTY1FArKCYZdfcx6Vj5HuEglurKy9+nKb0Bf/RTyETJM9eiftWORBlJmiRzDLH4iPr6EmGdhfTanCCQ==}
 
   '@storacha/one-webcrypto@1.0.1':
     resolution: {integrity: sha512-bD+vWmcgsEBqU0Dz04BR43SA03bBoLTAY29vaKasY9Oe8cb6XIP0/vkm0OS2UwKC13c8uRgFW4rjJUgDCNLejQ==}
@@ -100,9 +100,6 @@ packages:
   '@types/node@22.9.0':
     resolution: {integrity: sha512-vuyHg81vvWA1Z1ELfvLko2c8f34gyA0zaic0+Rllc5lbCnbSyuvb2Oxpm6TAUAC/2xZN3QGqxBNggD1nNR2AfQ==}
 
-  '@ucanto/client@9.0.1':
-    resolution: {integrity: sha512-cV8w3AnaZaYCdUmyFFICj8YhFckDoy2DvWgAzGDMkPz0WbUW4lw9Tjm4hEE8x5kiP47wYej/pHKWCcoELiU0qw==}
-
   '@ucanto/core@10.4.0':
     resolution: {integrity: sha512-ohLgxHUo/XgL1G/pvelsHl3zyq7w+fn6ZVN3yVhgiJwbRh67EqvjavXYEFGSLBzlAdMGsfDNkbetQob1sNSNGg==}
 
@@ -112,17 +109,11 @@ packages:
   '@ucanto/principal@9.0.2':
     resolution: {integrity: sha512-RE3Rj0oz4wh4C9p2JJZB9+QLd7Fi3lCixrbHgAvEoSyTNpvz6ky8DGNtttmD5j3O94z13qdVdIoSRY6DQZXfAg==}
 
-  '@ucanto/server@10.2.0':
-    resolution: {integrity: sha512-RKoh7m86V97Kk8LZRaKmF1f2HdT3iQNyAGYShx9gasEV3qUuTaq2k6gXBTBRiEaYjX27C3C/KSaTrmVCEPwp1g==}
-
   '@ucanto/transport@9.2.0':
     resolution: {integrity: sha512-w/CtD5LYEpGo/CxV78IiWalW99gNRPHKZ/DoOpart5QShozvnU//PwUqyqnGimZCDIrIq4LH6x92z2L/2k5OKQ==}
 
   '@ucanto/validator@9.1.0':
     resolution: {integrity: sha512-2JnEEZYc8kTZz+qbyL7LbI/TSpBRWLOchNhaRB5DTyj38FxMFQUXIB7gQ5lZHv49uYJGx/FXKPw0268WgJdEvg==}
-
-  '@web3-storage/content-claims@5.2.1':
-    resolution: {integrity: sha512-cOLxfzPJJo36CrbXEDtH/hNOIyB3gfF9cv8FS3QcK/OM1Xlsvihi4WvAX0aT6iql+P9Bcg9vRSthpLT2pU+t4g==}
 
   '@web3-storage/data-segment@5.3.0':
     resolution: {integrity: sha512-zFJ4m+pEKqtKatJNsFrk/2lHeFSbkXZ6KKXjBe7/2ayA9wAar7T/unewnOcZrrZTnCWmaxKsXWqdMFy9bXK9dw==}
@@ -173,9 +164,6 @@ packages:
 
   carstream@2.2.0:
     resolution: {integrity: sha512-/gHkK0lQjmGM45fhdx8JD+x7a1XS1qUk3T9xWWSt3oZiWPLq4u/lnDstp+N55K7hqTKKlb0CCr43EHTrlbmJSQ==}
-
-  carstream@2.3.0:
-    resolution: {integrity: sha512-2YwFg5Kxs2tqVCJv7sthWbYoUpALCYBBfTdpQcpicV7ipi6bBb1h9M4MNb1vm+724f39lUNp5VWhW43IFxfPlA==}
 
   cborg@4.2.6:
     resolution: {integrity: sha512-77vo4KlSwfjCIXcyZUVei4l2gdjesSCeYSx4U/Upwix7pcWZq8uw21sVRpjwn7mjEi//ieJPTj1MRWDHmud1Rg==}
@@ -509,7 +497,7 @@ snapshots:
   '@storacha/blob-index@1.0.6':
     dependencies:
       '@ipld/dag-cbor': 9.2.3
-      '@storacha/capabilities': 1.5.0
+      '@storacha/capabilities': 1.6.0
       '@storacha/one-webcrypto': 1.0.1
       '@ucanto/core': 10.4.0
       '@ucanto/interface': 10.3.0
@@ -517,7 +505,7 @@ snapshots:
       multiformats: 13.3.6
       uint8arrays: 5.1.0
 
-  '@storacha/capabilities@1.5.0':
+  '@storacha/capabilities@1.6.0':
     dependencies:
       '@ucanto/core': 10.4.0
       '@ucanto/interface': 10.3.0
@@ -525,7 +513,7 @@ snapshots:
       '@ucanto/transport': 9.2.0
       '@ucanto/validator': 9.1.0
       '@web3-storage/data-segment': 5.3.0
-      uint8arrays: 5.1.0
+      multiformats: 13.3.6
 
   '@storacha/one-webcrypto@1.0.1': {}
 
@@ -540,11 +528,6 @@ snapshots:
   '@types/node@22.9.0':
     dependencies:
       undici-types: 6.19.8
-
-  '@ucanto/client@9.0.1':
-    dependencies:
-      '@ucanto/core': 10.4.0
-      '@ucanto/interface': 10.3.0
 
   '@ucanto/core@10.4.0':
     dependencies:
@@ -569,13 +552,6 @@ snapshots:
       multiformats: 13.3.6
       one-webcrypto: 1.0.3
 
-  '@ucanto/server@10.2.0':
-    dependencies:
-      '@ucanto/core': 10.4.0
-      '@ucanto/interface': 10.3.0
-      '@ucanto/principal': 9.0.2
-      '@ucanto/validator': 9.1.0
-
   '@ucanto/transport@9.2.0':
     dependencies:
       '@ucanto/core': 10.4.0
@@ -587,16 +563,6 @@ snapshots:
       '@ipld/dag-cbor': 9.2.3
       '@ucanto/core': 10.4.0
       '@ucanto/interface': 10.3.0
-      multiformats: 13.3.6
-
-  '@web3-storage/content-claims@5.2.1':
-    dependencies:
-      '@ucanto/client': 9.0.1
-      '@ucanto/core': 10.4.0
-      '@ucanto/interface': 10.3.0
-      '@ucanto/server': 10.2.0
-      '@ucanto/transport': 9.2.0
-      carstream: 2.3.0
       multiformats: 13.3.6
 
   '@web3-storage/data-segment@5.3.0':
@@ -639,12 +605,6 @@ snapshots:
   camelcase@6.3.0: {}
 
   carstream@2.2.0:
-    dependencies:
-      '@ipld/dag-cbor': 9.2.3
-      multiformats: 13.3.6
-      uint8arraylist: 2.4.8
-
-  carstream@2.3.0:
     dependencies:
       '@ipld/dag-cbor': 9.2.3
       multiformats: 13.3.6

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,8 +12,8 @@ importers:
         specifier: ^9.2.3
         version: 9.2.3
       '@storacha/blob-index':
-        specifier: ^1.0.6
-        version: 1.0.6
+        specifier: 1.1.0-rc.0
+        version: 1.1.0-rc.0
       '@storacha/capabilities':
         specifier: ^1.6.0
         version: 1.6.0
@@ -78,8 +78,8 @@ packages:
     resolution: {integrity: sha512-1j6kQFb7QRru7eKN3ZDvRcP13rugwdxZqCjbiAVZfIJwgj2A65UmT4TgARXGlXgnRkORLTDTrO19ZErt7+QXgA==}
     engines: {node: ^14.21.3 || >=16}
 
-  '@storacha/blob-index@1.0.6':
-    resolution: {integrity: sha512-i0T942GU3cWI9uT2om00VRiSVypLQR47NHv97TXiDAJrZh+vT3oo2pJOjMZ9d5IDxFxDwhCN5pt/aMWLL1cj+Q==}
+  '@storacha/blob-index@1.1.0-rc.0':
+    resolution: {integrity: sha512-LTPfv0POAKbFJAem1Iz7utZzlh2auIhUZ7TQYz9YM9tZOWXwWz4oKXv6v0sXsqK5NGZsnolT5iQbNJ2f8GXZBg==}
     engines: {node: '>=16.15'}
 
   '@storacha/capabilities@1.6.0':
@@ -494,7 +494,7 @@ snapshots:
 
   '@noble/hashes@1.5.0': {}
 
-  '@storacha/blob-index@1.0.6':
+  '@storacha/blob-index@1.1.0-rc.0':
     dependencies:
       '@ipld/dag-cbor': 9.2.3
       '@storacha/capabilities': 1.6.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -43,8 +43,8 @@ importers:
         specifier: ^10.8.2
         version: 10.8.2
       typescript:
-        specifier: ^5.6.3
-        version: 5.6.3
+        specifier: ^5.8.3
+        version: 5.8.3
 
 packages:
 
@@ -407,8 +407,8 @@ packages:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
     engines: {node: '>=8.0'}
 
-  typescript@5.6.3:
-    resolution: {integrity: sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw==}
+  typescript@5.8.3:
+    resolution: {integrity: sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==}
     engines: {node: '>=14.17'}
     hasBin: true
 
@@ -840,7 +840,7 @@ snapshots:
     dependencies:
       is-number: 7.0.0
 
-  typescript@5.6.3: {}
+  typescript@5.8.3: {}
 
   uint8arraylist@2.4.8:
     dependencies:

--- a/src/api.ts
+++ b/src/api.ts
@@ -1,12 +1,12 @@
 import { MultihashDigest, Link, UnknownLink } from 'multiformats'
 import { Ability, BlockStore, Capability, Capabilities, Caveats, Delegation, Failure, Resource, Result, DID, IPLDView, IPLDBlock, UCANLink, ServiceMethod } from '@ucanto/interface'
 import { DecodeFailure, EncodeFailure, ShardedDAGIndex, ShardedDAGIndexView, UnknownFormat } from '@storacha/blob-index/types'
-import { AssertLocation, AssertPartition, AssertInclusion, AssertIndex, AssertEquals, AssertRelation } from '@storacha/capabilities/types'
+import { AssertLocation, AssertPartition, AssertInclusion, AssertIndex, AssertEquals, AssertRelation, ClaimCache } from '@storacha/capabilities/types'
 
 export type { MultihashDigest, Link }
 export type { Ability, BlockStore, Capability, Capabilities, Caveats, Delegation, Failure, Resource, Result, DID, IPLDView, IPLDBlock, UCANLink }
 export type { DecodeFailure, EncodeFailure, ShardedDAGIndex, ShardedDAGIndexView, UnknownFormat }
-export type { AssertLocation, AssertPartition, AssertInclusion, AssertIndex, AssertEquals, AssertRelation }
+export type { AssertLocation, AssertPartition, AssertInclusion, AssertIndex, AssertEquals, AssertRelation, ClaimCache }
 
 export interface IndexingServiceClient {
   queryClaims (q: Query): Promise<Result<QueryOk, QueryError>>
@@ -116,5 +116,8 @@ export interface IndexingService {
   assert: {
     index: ServiceMethod<AssertIndex, {}, Failure>
     equals: ServiceMethod<AssertEquals, {}, Failure>
+  },
+  claim: {
+    cache: ServiceMethod<ClaimCache, {}, Failure>
   }
 }

--- a/src/api.ts
+++ b/src/api.ts
@@ -113,7 +113,8 @@ export type Claim =
 
 /** Indexing service accepts invocations of claims for data. */
 export interface IndexingService {
-  location: ServiceMethod<AssertLocation, {}, Failure>
-  index: ServiceMethod<AssertIndex, {}, Failure>
-  equals: ServiceMethod<AssertEquals, {}, Failure>
+  assert: {
+    index: ServiceMethod<AssertIndex, {}, Failure>
+    equals: ServiceMethod<AssertEquals, {}, Failure>
+  }
 }

--- a/src/api.ts
+++ b/src/api.ts
@@ -1,12 +1,12 @@
-import { MultihashDigest, Link } from 'multiformats'
-import { Delegation, Failure, Result, DID, IPLDView, IPLDBlock, UCANLink } from '@ucanto/interface'
+import { MultihashDigest, Link, UnknownLink } from 'multiformats'
+import { Ability, BlockStore, Capability, Capabilities, Caveats, Delegation, Failure, Resource, Result, DID, IPLDView, IPLDBlock, UCANLink } from '@ucanto/interface'
 import { DecodeFailure, ShardedDAGIndex, ShardedDAGIndexView, UnknownFormat } from '@storacha/blob-index/types'
-import { Claim } from '@web3-storage/content-claims/client/api'
+import { AssertLocation, AssertPartition, AssertInclusion, AssertIndex, AssertEquals, AssertRelation } from '@storacha/capabilities/types'
 
 export type { MultihashDigest, Link }
-export type { Delegation, Failure, Result, DID, IPLDView, IPLDBlock, UCANLink }
+export type { Ability, BlockStore, Capability, Capabilities, Caveats, Delegation, Failure, Resource, Result, DID, IPLDView, IPLDBlock, UCANLink }
 export type { DecodeFailure, ShardedDAGIndex, ShardedDAGIndexView, UnknownFormat }
-export type { Claim }
+export type { AssertLocation, AssertPartition, AssertInclusion, AssertIndex, AssertEquals, AssertRelation }
 
 export interface IndexingServiceClient {
   queryClaims (q: Query): Promise<Result<QueryOk, QueryError>>
@@ -51,3 +51,62 @@ export interface InvalidQuery extends Failure {
 export interface NetworkError extends Failure {
   name: 'NetworkError'
 }
+
+export type InferCaveats<C extends Capability> = C extends Capability<Ability, Resource, infer NB> ? NB : never
+
+export interface ContentCaveats {
+  content: UnknownLink | { digest: Uint8Array } 
+}
+
+export interface ClaimCapability<Can extends Ability = Ability, With extends Resource = Resource, Caveats extends ContentCaveats = ContentCaveats> extends Capability<Can, With, Caveats> {
+  nb: Caveats
+}
+
+/** A verifiable claim about data. */
+export interface ContentClaim<C extends ClaimCapability = ClaimCapability> {
+  /** Subject of the claim e.g. CAR, DAG root etc. */
+  readonly content: C['nb']['content']
+  /** Discriminator for different types of claims. */
+  readonly type: C['can']
+  /** Returns the underlying delegation this claim is based on. */
+  delegation(): Delegation<[C]>
+}
+
+/** A claim not known to this library. */
+export interface UnknownClaim extends ContentClaim {}
+
+/** A claim that a CID is available at a URL. */
+export interface LocationCommitment extends ContentClaim<AssertLocation>, Readonly<Omit<InferCaveats<AssertLocation>, 'content'>> {
+}
+
+/** A claim that a CID's graph can be read from the blocks found in parts. */
+export interface PartitionClaim extends ContentClaim<AssertPartition>, Readonly<Omit<InferCaveats<AssertPartition>, 'content'>> {
+}
+
+/** A claim that a CID includes the contents claimed in another CID. */
+export interface InclusionClaim extends ContentClaim<AssertInclusion>, Readonly<Omit<InferCaveats<AssertInclusion>, 'content'>> {
+}
+
+/**
+ * A claim that a content graph can be found in blob(s) that are identified and
+ * indexed in the given index CID.
+ */
+export interface IndexClaim extends ContentClaim<AssertIndex>, Readonly<Omit<InferCaveats<AssertIndex>, 'content'>> {
+}
+
+/** A claim that a CID links to other CIDs. */
+export interface RelationClaim extends ContentClaim<AssertRelation>, Readonly<Omit<InferCaveats<AssertRelation>, 'content'>> {
+}
+
+/** A claim that the same data is referred to by another CID and/or multihash */
+export interface EqualsClaim extends ContentClaim<AssertEquals>, Readonly<Omit<InferCaveats<AssertEquals>, 'content'>> {
+}
+
+/** A verifiable claim about data. */
+export type Claim =
+  | LocationCommitment
+  | PartitionClaim
+  | InclusionClaim
+  | IndexClaim
+  | RelationClaim
+  | EqualsClaim

--- a/src/api.ts
+++ b/src/api.ts
@@ -1,11 +1,11 @@
 import { MultihashDigest, Link, UnknownLink } from 'multiformats'
 import { Ability, BlockStore, Capability, Capabilities, Caveats, Delegation, Failure, Resource, Result, DID, IPLDView, IPLDBlock, UCANLink, ServiceMethod } from '@ucanto/interface'
-import { DecodeFailure, ShardedDAGIndex, ShardedDAGIndexView, UnknownFormat } from '@storacha/blob-index/types'
+import { DecodeFailure, EncodeFailure, ShardedDAGIndex, ShardedDAGIndexView, UnknownFormat } from '@storacha/blob-index/types'
 import { AssertLocation, AssertPartition, AssertInclusion, AssertIndex, AssertEquals, AssertRelation } from '@storacha/capabilities/types'
 
 export type { MultihashDigest, Link }
 export type { Ability, BlockStore, Capability, Capabilities, Caveats, Delegation, Failure, Resource, Result, DID, IPLDView, IPLDBlock, UCANLink }
-export type { DecodeFailure, ShardedDAGIndex, ShardedDAGIndexView, UnknownFormat }
+export type { DecodeFailure, EncodeFailure, ShardedDAGIndex, ShardedDAGIndexView, UnknownFormat }
 export type { AssertLocation, AssertPartition, AssertInclusion, AssertIndex, AssertEquals, AssertRelation }
 
 export interface IndexingServiceClient {
@@ -35,7 +35,7 @@ export interface QueryOk extends QueryResult {}
 export interface QueryResult extends IPLDView {
   claims: Map<string, Claim>
   indexes: Map<string, ShardedDAGIndex>
-  archive (): Promise<Result<Uint8Array>>
+  archive (): Promise<Result<Uint8Array, EncodeFailure>>
 }
 
 export type QueryError =

--- a/src/api.ts
+++ b/src/api.ts
@@ -1,5 +1,5 @@
 import { MultihashDigest, Link, UnknownLink } from 'multiformats'
-import { Ability, BlockStore, Capability, Capabilities, Caveats, Delegation, Failure, Resource, Result, DID, IPLDView, IPLDBlock, UCANLink } from '@ucanto/interface'
+import { Ability, BlockStore, Capability, Capabilities, Caveats, Delegation, Failure, Resource, Result, DID, IPLDView, IPLDBlock, UCANLink, ServiceMethod } from '@ucanto/interface'
 import { DecodeFailure, ShardedDAGIndex, ShardedDAGIndexView, UnknownFormat } from '@storacha/blob-index/types'
 import { AssertLocation, AssertPartition, AssertInclusion, AssertIndex, AssertEquals, AssertRelation } from '@storacha/capabilities/types'
 
@@ -110,3 +110,10 @@ export type Claim =
   | IndexClaim
   | RelationClaim
   | EqualsClaim
+
+/** Indexing service accepts invocations of claims for data. */
+export interface IndexingService {
+  location: ServiceMethod<AssertLocation, {}, Failure>
+  index: ServiceMethod<AssertIndex, {}, Failure>
+  equals: ServiceMethod<AssertEquals, {}, Failure>
+}

--- a/src/claim.js
+++ b/src/claim.js
@@ -1,0 +1,37 @@
+/** @import * as API from './api.js' */
+import * as Delegation from '@ucanto/core/delegation'
+import * as Assert from '@storacha/capabilities/assert'
+
+const assertCapMap = {
+  [Assert.location.can]: Assert.location,
+  [Assert.partition.can]: Assert.partition,
+  [Assert.inclusion.can]: Assert.inclusion,
+  [Assert.index.can]: Assert.index,
+  [Assert.relation.can]: Assert.relation,
+  [Assert.equals.can]: Assert.equals
+}
+
+/**
+ * @template {API.Capabilities} C
+ * @param {object} dag
+ * @param {API.UCANLink<C>} dag.root
+ * @param {API.BlockStore<unknown>} dag.blocks
+ * @returns {import('./api.js').Claim}
+ */
+export const view = ({ root, blocks }) => {
+  const delegation = Delegation.view({ root, blocks })
+  const cap = delegation.capabilities[0]
+  const capability = assertCapMap[
+    /** @type {keyof typeof assertCapMap} */
+    (cap.can)
+  ]
+  if (!capability) throw new Error(`Unsupported capability: ${cap.can}`)
+  // @ts-expect-error cap is unknown
+  const parsedCap = capability.create(cap)
+  return {
+    ...parsedCap.nb,
+    type: parsedCap.can,
+    // @ts-expect-error
+    delegation: () => delegation,
+  }
+}

--- a/src/query-result.js
+++ b/src/query-result.js
@@ -1,12 +1,12 @@
 /** @import * as API from './api.js' */
 import * as CBOR from '@ipld/dag-cbor'
 import { create as createLink } from 'multiformats/link'
-import { ok, error, Schema, Delegation } from '@ucanto/core'
+import { ok, error, Schema } from '@ucanto/core'
 import * as CAR from '@ucanto/core/car'
 import * as ShardedDAGIndex from '@storacha/blob-index/sharded-dag-index'
 import { UnknownFormatError, DecodeError } from './errors.js'
 import { sha256 } from 'multiformats/hashes/sha2'
-import { decodeDelegation } from '@web3-storage/content-claims/client'
+import * as Claim from './claim.js'
 
 export const version = 'index/query/result@0.1'
 
@@ -50,10 +50,10 @@ export const view = async ({ root, blocks }) => {
       for (const root of parsed.claims ?? []) {
         let claim
         try {
-          claim = await decodeDelegation(Delegation.view({
+          claim = Claim.view({
             root: /** @type {API.UCANLink} */ (root),
             blocks
-          }))
+          })
         } catch (/** @type {any} */ err) {
           return error(new DecodeError(`decoding claim: ${root}: ${err.message}`))
         }

--- a/src/query-result.js
+++ b/src/query-result.js
@@ -88,48 +88,57 @@ export const view = async ({ root, blocks }) => {
  *   claims?: API.Claim[]
  *   indexes?: Map<ContextID, API.ShardedDAGIndexView>
  * }} param
+ * @returns {Promise<API.Result<API.QueryResult, API.EncodeFailure>>}
  */
 export const from = async ({ claims, indexes }) => {
-  const blocks = new Map()
-  const rootData = {
-    'index/query/result@0.1': {
-      claims: /** @type {API.Link[]} **/ ([]),
-      indexes: /** @type {Record<string, API.Link>} */ ({})
-    }
-  }
-  const data = { claims: new Map(), indexes: new Map() }
-
-  if (claims) {
-    for (const claim of claims) {
-      rootData['index/query/result@0.1'].claims.push(claim.delegation().link())
-      for (const block of claim.delegation().iterateIPLDBlocks()) {
-        blocks.set(block.cid.toString(), block)
+  try {
+    const blocks = new Map()
+    const rootData = {
+      'index/query/result@0.1': {
+        claims: /** @type {API.Link[]} **/ ([]),
+        indexes: /** @type {Record<string, API.Link>} */ ({})
       }
-      data.claims.set(claim.delegation().link().toString(), claim)
     }
-  }
+    const data = { claims: new Map(), indexes: new Map() }
 
-  if (indexes) {
-    for (const [contextID, index] of indexes.entries()) {
-      const result = await index.archive()
-      if (!result.ok) {
-        return result
+    if (claims) {
+      for (const claim of claims) {
+        rootData['index/query/result@0.1'].claims.push(claim.delegation().link())
+        for (const block of claim.delegation().iterateIPLDBlocks()) {
+          blocks.set(block.cid.toString(), block)
+        }
+        data.claims.set(claim.delegation().link().toString(), claim)
       }
-      const digest = await sha256.digest(result.ok)
-      const link = createLink(CAR.code, digest)
-      rootData['index/query/result@0.1'].indexes[contextID] = link
-      blocks.set(link.toString(), { cid: link, bytes: result.ok })
-      data.indexes.set(link.toString(), index)
     }
+
+    if (indexes) {
+      for (const [contextID, index] of indexes.entries()) {
+        const result = await index.archive()
+        if (!result.ok) {
+          return result
+        }
+        const digest = await sha256.digest(result.ok)
+        const link = createLink(CAR.code, digest)
+        rootData['index/query/result@0.1'].indexes[contextID] = link
+        blocks.set(link.toString(), { cid: link, bytes: result.ok })
+        data.indexes.set(link.toString(), index)
+      }
+    }
+
+    const rootBytes = CBOR.encode(rootData)
+    const rootDigest = await sha256.digest(rootBytes)
+    const rootLink = createLink(CBOR.code, rootDigest)
+    const root = { cid: rootLink, bytes: rootBytes }
+    blocks.set(rootLink.toString(), root)
+
+    return ok(new QueryResult({ root, blocks, data }))
+  } catch (/** @type {any} */ err) {
+    return error(/** @type {API.EncodeFailure} */ ({
+      name: 'EncodeFailure',
+      message: `encoding DAG: ${err.message}`,
+      stack: err.stack
+    }))
   }
-
-  const rootBytes = CBOR.encode(rootData)
-  const rootDigest = await sha256.digest(rootBytes)
-  const rootLink = createLink(CBOR.code, rootDigest)
-  const root = { cid: rootLink, bytes: rootBytes }
-  blocks.set(rootLink.toString(), root)
-
-  return ok(new QueryResult({ root, blocks, data }))
 }
 
 class QueryResult {
@@ -176,14 +185,22 @@ class QueryResult {
 
 /**
  * @param {API.QueryResult} result
- * @returns {Promise<API.Result<Uint8Array>>}
+ * @returns {Promise<API.Result<Uint8Array, API.EncodeFailure>>}
  */
 export const archive = async (result) => {
-  const blocks = new Map()
-  for (const block of result.iterateIPLDBlocks()) {
-    blocks.set(block.cid.toString(), block)
+  try {
+    const blocks = new Map()
+    for (const block of result.iterateIPLDBlocks()) {
+      blocks.set(block.cid.toString(), block)
+    }
+    return ok(CAR.encode({ roots: [result.root], blocks }))
+  } catch (/** @type {any} */ err) {
+    return error(/** @type {API.EncodeFailure} */ ({
+      name: 'EncodeFailure',
+      message: `encoding CAR: ${err.message}`,
+      stack: err.stack
+    }))
   }
-  return ok(CAR.encode({ roots: [result.root], blocks }))
 }
 
 /**

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -6,8 +6,12 @@ import * as Digest from 'multiformats/hashes/digest'
 import { base58btc } from 'multiformats/bases/base58'
 import { equals } from 'multiformats/bytes'
 import { Client } from '../src/index.js'
-import { contentMultihash } from '@web3-storage/content-claims/client'
-/** @import { Link } from '../src/api.js' */
+
+/** @import { Link, Claim } from '../src/api.js' */
+
+/** @param {Claim} claim */
+const contentDigest = (claim) =>
+  'digest' in claim.content ? Digest.decode(claim.content.digest) : claim.content.multihash
 
 describe('indexing service client', () => {
   it('queries claims', async () => {
@@ -26,7 +30,7 @@ describe('indexing service client', () => {
     })
     assert(indexClaim)
 
-    assert(equals(digest.bytes, contentMultihash(indexClaim).bytes))
+    assert(equals(digest.bytes, contentDigest(indexClaim).bytes))
 
     // index should be included in results
     const index = result.ok.indexes.get(indexClaim.index.toString())
@@ -35,7 +39,7 @@ describe('indexing service client', () => {
     // find location claim for the index
     const indexLocationCommitment = [...result.ok.claims.values()].filter(c => {
       return c.type === 'assert/location'
-    }).find(c => equals(contentMultihash(c).bytes, indexClaim.index.multihash.bytes))
+    }).find(c => equals(contentDigest(c).bytes, indexClaim.index.multihash.bytes))
     assert(indexLocationCommitment)
 
     assert(indexLocationCommitment.location)
@@ -46,7 +50,7 @@ describe('indexing service client', () => {
     const [[shard, slices]] = index.shards.entries()
     const shardLocationCommitment = [...result.ok.claims.values()].filter(c => {
       return c.type === 'assert/location'
-    }).find(c => equals(contentMultihash(c).bytes, shard.bytes))
+    }).find(c => equals(contentDigest(c).bytes, shard.bytes))
     assert(shardLocationCommitment)
 
     assert(shardLocationCommitment.location)

--- a/test/query-result.spec.js
+++ b/test/query-result.spec.js
@@ -29,4 +29,18 @@ describe('query result', () => {
     assert.equal(extract0.ok.claims.size, extract1.ok.claims.size)
     assert.equal(extract0.ok.indexes.size, extract1.ok.indexes.size)
   })
+
+  it('from encode failure', async () => {
+    // @ts-expect-error for test
+    const res = await QueryResult.from({ claims: 'none' })
+    assert.ok(res.error)
+    assert.equal(res.error.name, 'EncodeFailure')
+  })
+
+  it('archive encode failure', async () => {
+    // @ts-expect-error for test
+    const res = await QueryResult.archive(undefined)
+    assert.ok(res.error)
+    assert.equal(res.error.name, 'EncodeFailure')
+  })
 })


### PR DESCRIPTION
Removes legacy content claims library (`@web3-storage/content-claims`).

I've moved the types and constructor for the content claims views here - they are only used when you're querying for data and this is the only way to query it currently.

I have also renamed the `LocationClaim` type to `LocationCommitment`.

depends on:
* [x] https://github.com/storacha/upload-service/pull/276 
* [x] https://github.com/storacha/upload-service/pull/277