### PR TITLE
feat: client combiner

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,10 @@
     "./query-result": {
       "import": "./src/query-result.js",
       "types": "./dist/src/query-result.d.ts"
+    },
+    "./util": {
+      "import": "./src/util.js",
+      "types": "./dist/src/util.d.ts"
     }
   },
   "dependencies": {
@@ -44,6 +48,7 @@
     "@types/chai": "^5.0.1",
     "@types/mocha": "^10.0.9",
     "@types/node": "^22.9.0",
+    "@ucanto/principal": "^9.0.2",
     "chai": "^5.1.2",
     "mocha": "^10.8.2",
     "typescript": "^5.8.3"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -36,6 +36,9 @@ importers:
       '@types/node':
         specifier: ^22.9.0
         version: 22.9.0
+      '@ucanto/principal':
+        specifier: ^9.0.2
+        version: 9.0.2
       chai:
         specifier: ^5.1.2
         version: 5.1.2

--- a/src/util.js
+++ b/src/util.js
@@ -1,0 +1,51 @@
+import { error } from '@ucanto/core'
+import * as QueryResult from './query-result.js'
+
+/** @import { IndexingServiceClient, QueryError } from './api.js' */
+
+/**
+ * Combines the passed clients into a single client. When querying claims, error
+ * responses are ignored unless ALL clients return an error. If all clients
+ * return an error then the first error encountered is returned.
+ *
+ * @param {IndexingServiceClient[]} clients
+ * @returns {IndexingServiceClient}
+ */
+export const combine = (clients) => {
+  if (!clients.length) {
+    throw new Error('missing indexing service clients')
+  }
+  return {
+    async queryClaims (q) {
+      const results = await Promise.all(clients.map(c => c.queryClaims(q)))
+      const claims = []
+      const indexes = new Map()
+      const errors = []
+      for (const res of results) {
+        if (res.error) {
+          errors.push(res.error)
+          continue
+        }
+        for (const [, v] of res.ok.claims) {
+          claims.push(v)
+        }
+        for (const [k, v] of res.ok.indexes) {
+          indexes.set(k, v)
+        }
+      }
+      if (errors.length === results.length) {
+        return results[0]
+      }
+      const fromRes = await QueryResult.from({ claims, indexes })
+      if (fromRes.error) {
+        // shoud not happen - we already decoded so re-encoding should work
+        return error(/** @type {QueryError} */ ({
+          ...fromRes.error,
+          name: 'UnknownFormat',
+          message: `failed to combine results: ${fromRes.error.message}`
+        }))
+      }
+      return fromRes
+    }
+  }
+}

--- a/test/util.spec.js
+++ b/test/util.spec.js
@@ -1,0 +1,90 @@
+import { describe, it } from 'mocha'
+import { assert } from 'chai'
+import { Assert } from '@storacha/capabilities'
+import * as ed25519 from '@ucanto/principal/ed25519'
+import { ShardedDAGIndex } from '@storacha/blob-index'
+import { sha256 } from 'multiformats/hashes/sha2'
+import * as Link from 'multiformats/link'
+import * as raw from 'multiformats/codecs/raw'
+import * as Claim from '../src/claim.js'
+import * as QueryResult from '../src/query-result.js'
+import { Client } from '../src/index.js'
+import { combine } from '../src/util.js'
+
+/** @import { URI } from '@ucanto/interface' */
+
+/** @param {number} size */
+const randomBytes = size => crypto.getRandomValues(new Uint8Array(size))
+const randomDigest = () => sha256.digest(randomBytes(32))
+const randomLink = async () => Link.create(raw.code, await randomDigest())
+/** @param {Uint8Array} bytes */
+const toCARLink = async bytes => Link.create(0x0202, await sha256.digest(bytes))
+
+/** @param {import('multiformats').Link} content */
+const setup = async (content) => {
+  const storageNode = await ed25519.generate()
+  const space = await ed25519.generate()
+
+  const domain = storageNode.did().replace('did:key:', '')
+  const url = /** @type {URI} */ (`http://${domain}.example.com`)
+  const site = await Assert.location.delegate({
+    issuer: storageNode,
+    audience: space,
+    with: storageNode.did(),
+    nb: { content, location: [url] }
+  })
+
+  const index = ShardedDAGIndex.create(content)
+  index.setSlice(await randomDigest(), await randomDigest(), [0, 100])
+
+  const indexArchiveRes = await index.archive()
+  assert(indexArchiveRes.ok)
+
+  const indexLink = await toCARLink(indexArchiveRes.ok)
+
+  const blocks = new Map()
+  for (const b of site.export()) {
+    blocks.set(b.cid.toString(), b)
+  }
+
+  const result = await QueryResult.from({
+    claims: [Claim.view({ root: site.cid, blocks })],
+    indexes: new Map([['index', index]])
+  })
+  assert(result.ok)
+
+  const queryArchiveRes = await QueryResult.archive(result.ok)
+  assert(queryArchiveRes.ok)
+
+  const client = new Client({
+    fetch: async () => new Response(queryArchiveRes.ok)
+  })
+
+  return { client, claim: site.cid, index: indexLink }
+}
+
+describe('combine', () => {
+  it('combines multiple clients', async () => {
+    const content = await randomLink()
+
+    const service0 = await setup(content)
+    const service1 = await setup(content)
+
+    const client = combine([service0.client, service1.client])
+    const queryRes = await client.queryClaims({ hashes: [content.multihash] })
+    assert(queryRes.ok)
+
+    const claims = [...queryRes.ok.claims.values()]
+    assert(claims.some(c => c.delegation().cid.toString() === service0.claim.toString()))
+    assert(claims.some(c => c.delegation().cid.toString() === service1.claim.toString()))
+
+    const indexs = []
+    for (const [,index] of queryRes.ok.indexes) {
+      const archiveRes = await ShardedDAGIndex.archive(index)
+      assert(archiveRes.ok)
+      indexs.push(await toCARLink(archiveRes.ok))
+    }
+    assert(indexs.some(i => i.toString() === service0.index.toString()))
+    assert(indexs.some(i => i.toString() === service1.index.toString()))
+  })
+})


### PR DESCRIPTION
This PR adds a function that combines multiple indexing service clients into one.

Why do we need this?

The warm storage network will have a separate indexing service. Yet it will use the same filecoin pipeline as the regaular network. Roundabout, the service that maps piece CIDs to shard URLs needs to be able to operate across both networks.